### PR TITLE
Fix providers not properly set when registering an NFT

### DIFF
--- a/integration/nevermined/NFTApi.e2e.test.ts
+++ b/integration/nevermined/NFTApi.e2e.test.ts
@@ -1,4 +1,5 @@
 import { assert } from 'chai'
+import Web3 from 'web3'
 import { Account, DDO, Nevermined } from '../../src'
 import { EscrowPaymentCondition } from '../../src/keeper/contracts/conditions'
 import Token from '../../src/keeper/contracts/Token'
@@ -81,6 +82,13 @@ describe('NFTs Api End-to-End', () => {
 
             const balance = await nevermined.nfts.balance(ddo.id, artist)
             assert.equal(balance, 5)
+        })
+
+        it('Should set the gateway as a provider by default', async () => {
+            const providers = await nevermined.provider.list(ddo.id)
+            assert.deepEqual(providers, [
+                Web3.utils.toChecksumAddress(config.gatewayAddress)
+            ])
         })
     })
 

--- a/src/nevermined/Nfts.ts
+++ b/src/nevermined/Nfts.ts
@@ -49,7 +49,7 @@ export class Nfts extends Instantiable {
             assetRewards,
             undefined,
             cap,
-            [],
+            undefined,
             nftAmount,
             royalties,
             erc20TokenAddress


### PR DESCRIPTION
## Description

- Fix an issue where providers are not properly set when registering an attribute through `nfts.create`
- Added tests

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [x] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()