### PR TITLE
Adding `mint` parameter to `registerMintableDID`

### DIFF
--- a/integration/nevermined/NFTTemplates.test.ts
+++ b/integration/nevermined/NFTTemplates.test.ts
@@ -177,6 +177,7 @@ describe('NFTTemplates E2E', () => {
                     '',
                     cappedAmount,
                     royalties,
+                    false,
                     artist.getId()
                 )
 

--- a/integration/nevermined/NFTTemplatesWithEther.test.ts
+++ b/integration/nevermined/NFTTemplatesWithEther.test.ts
@@ -146,6 +146,7 @@ describe('NFTTemplates With Ether E2E', async () => {
                     '',
                     cappedAmount,
                     royalties,
+                    false,
                     artist.getId()
                 )
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nevermined-io/nevermined-sdk-js",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Javascript SDK for connecting with Nevermined Data Platform ",
   "main": "./dist/node/sdk.js",
   "typings": "./dist/node/sdk.d.ts",
@@ -53,7 +53,7 @@
     "web3": "^1.2.3"
   },
   "dependencies": {
-    "@nevermined-io/contracts": "^1.3.1",
+    "@nevermined-io/contracts": "^1.3.2",
     "@nevermined-io/secret-store-client": "^0.0.16",
     "bignumber.js": "^9.0.0",
     "circom": "^0.5.45",

--- a/src/keeper/contracts/DIDRegistry.ts
+++ b/src/keeper/contracts/DIDRegistry.ts
@@ -150,6 +150,7 @@ export default class DIDRegistry extends ContractBase {
         attributes: string,
         cap: number,
         royalties: number,
+        mint: boolean = false,
         ownerAddress: string,
         params?: TxParameters
     ) {
@@ -163,6 +164,7 @@ export default class DIDRegistry extends ContractBase {
                 value,
                 String(cap),
                 String(royalties),
+                mint,
                 zeroX(activityId),
                 attributes
             ],

--- a/src/nevermined/Assets.ts
+++ b/src/nevermined/Assets.ts
@@ -316,6 +316,7 @@ export class Assets extends Instantiable {
                 '',
                 1,
                 royalties,
+                false,
                 publisher.getId(),
                 txParams
             )

--- a/test/keeper/conditions/NFTHolderCondition.test.ts
+++ b/test/keeper/conditions/NFTHolderCondition.test.ts
@@ -89,6 +89,7 @@ describe('NFTHolderCondition', () => {
                 '',
                 100,
                 0,
+                false,
                 owner.getId()
             )
             await didRegistry.mint(did, 10, owner.getId())
@@ -129,6 +130,7 @@ describe('NFTHolderCondition', () => {
                 '',
                 100,
                 0,
+                false,
                 owner.getId()
             )
             const did = await didRegistry.hashDID(didSeed, owner.getId())
@@ -170,6 +172,7 @@ describe('NFTHolderCondition', () => {
                 '',
                 100,
                 0,
+                false,
                 owner.getId()
             )
             await didRegistry.mint(did, 10, owner.getId())

--- a/test/keeper/conditions/NFTLockCondition.test.ts
+++ b/test/keeper/conditions/NFTLockCondition.test.ts
@@ -80,6 +80,7 @@ describe('NFTLockCondition', () => {
                 '',
                 amount,
                 0,
+                false,
                 owner.getId()
             )
             const did = await didRegistry.hashDID(didSeed, owner.getId())
@@ -143,6 +144,7 @@ describe('NFTLockCondition', () => {
                 '',
                 amount,
                 0,
+                false,
                 owner.getId()
             )
             const did = await didRegistry.hashDID(didSeed, owner.getId())
@@ -170,6 +172,7 @@ describe('NFTLockCondition', () => {
                 '',
                 amount,
                 0,
+                false,
                 owner.getId()
             )
             const did = await didRegistry.hashDID(didSeed, owner.getId())
@@ -215,6 +218,7 @@ describe('NFTLockCondition', () => {
                 '',
                 amount,
                 0,
+                false,
                 owner.getId()
             )
             const did = await didRegistry.hashDID(didSeed, owner.getId())

--- a/test/keeper/conditions/TransferNFTCondition.test.ts
+++ b/test/keeper/conditions/TransferNFTCondition.test.ts
@@ -123,9 +123,10 @@ describe('TransferNFTCondition', () => {
                 '',
                 nftAmount,
                 0,
+                true, // Minting during registration
                 owner.getId()
             )
-            await didRegistry.mint(did, nftAmount, owner.getId())
+            // await didRegistry.mint(did, nftAmount, owner.getId())
 
             await nftReceiver.requestTokens(10)
             await nevermined.keeper.token.approve(
@@ -221,6 +222,7 @@ describe('TransferNFTCondition', () => {
                 '',
                 nftAmount,
                 0,
+                false,
                 owner.getId()
             )
             await didRegistry.mint(did, nftAmount, owner.getId())
@@ -314,6 +316,7 @@ describe('TransferNFTCondition', () => {
                 '',
                 nftAmount,
                 0,
+                false,
                 owner.getId()
             )
             await didRegistry.mint(did, nftAmount, owner.getId())


### PR DESCRIPTION
## Description

This new parameter allows to mint directly the ERC-1155 NFT attached to an asset during the registration process

## Is this PR related with an open issue?

Related to Issue #164 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

