### PR TITLE
Refactor ContractEvents to make it easier to integrate graph

### DIFF
--- a/src/keeper/ContractEvent.ts
+++ b/src/keeper/ContractEvent.ts
@@ -1,3 +1,4 @@
+import { Instantiable } from '../Instantiable.abstract'
 import ContractBase from './contracts/ContractBase'
 
 interface EventEmitter {
@@ -9,17 +10,19 @@ export interface ContractEventSubscription {
     unsubscribe: () => void
 }
 
-export class ContractEvent {
+export class ContractEvent extends Instantiable {
     constructor(
-        private eventEmitter: EventEmitter,
         private contract: ContractBase,
-        private eventName: string,
-        private filter: { [key: string]: any }
-    ) {}
+        private eventEmitter?: EventEmitter,
+        private eventName?: string,
+        private filter?: { [key: string]: any }
+    ) {
+        super()
+    }
 
     public subscribe(callback: (events: any[]) => void): ContractEventSubscription {
         const onEvent = async (blockNumber: number) => {
-            const events = await this.contract.getEventData(this.eventName, {
+            const events = await this.getEventData(this.eventName, {
                 filter: this.filter,
                 fromBlock: blockNumber,
                 toBlock: 'latest'
@@ -44,6 +47,35 @@ export class ContractEvent {
                 }
                 resolve(events)
             })
+        })
+    }
+
+    public async getEventData(eventName: string, options: any) {
+        if (!this.contract.contract.events[eventName]) {
+            throw new Error(
+                `Event "${eventName}" not found on contract "${this.contract.contractName}"`
+            )
+        }
+        return this.contract.contract.getPastEvents(eventName, options)
+    }
+
+    public async getPastEvents(eventName: string, filter: { [key: string]: any }) {
+        const chainId = await this.web3.eth.net.getId()
+
+        let fromBlock = 0
+        const toBlock = 'latest'
+
+        // Temporary workaround to work with mumbai
+        // Infura as a 1000 blokcs limit on their api
+        if (chainId === 80001) {
+            const latestBlock = await this.web3.eth.getBlockNumber()
+            fromBlock = latestBlock - 990
+        }
+
+        return this.getEventData(eventName, {
+            filter,
+            fromBlock,
+            toBlock
         })
     }
 }

--- a/src/keeper/EventHandler.ts
+++ b/src/keeper/EventHandler.ts
@@ -46,7 +46,7 @@ export class EventHandler extends Instantiable {
         eventName: string,
         filter: { [key: string]: any }
     ) {
-        return new ContractEvent(this, contract, eventName, filter)
+        return new ContractEvent(contract, this, eventName, filter)
     }
 
     private async checkBlock(isInterval?: boolean, n = 0) {

--- a/src/keeper/contracts/ContractBase.ts
+++ b/src/keeper/contracts/ContractBase.ts
@@ -4,6 +4,7 @@ import ContractHandler from '../ContractHandler'
 
 import { Instantiable, InstantiableConfig } from '../../Instantiable.abstract'
 import Account from '../../nevermined/Account'
+import { ContractEvent } from '../ContractEvent'
 
 export interface TxParameters {
     value?: string
@@ -19,8 +20,8 @@ export abstract class ContractBase extends Instantiable {
     protected static instance = null
 
     public contractName: string
-
-    protected contract: Contract = null
+    public contract: Contract = null
+    public events: ContractEvent = null
 
     get address() {
         return this.getAddress()
@@ -29,35 +30,7 @@ export abstract class ContractBase extends Instantiable {
     constructor(contractName: string, private optional: boolean = false) {
         super()
         this.contractName = contractName
-    }
-
-    public async getEventData(eventName: string, options: any) {
-        if (!this.contract.events[eventName]) {
-            throw new Error(
-                `Event "${eventName}" not found on contract "${this.contractName}"`
-            )
-        }
-        return this.contract.getPastEvents(eventName, options)
-    }
-
-    public async getPastEvents(eventName: string, filter: { [key: string]: any }) {
-        const chainId = await this.web3.eth.net.getId()
-
-        let fromBlock = 0
-        const toBlock = 'latest'
-
-        // Temporary workaround to work with mumbai
-        // Infura as a 1000 blokcs limit on their api
-        if (chainId === 80001) {
-            const latestBlock = await this.web3.eth.getBlockNumber()
-            fromBlock = latestBlock - 990
-        }
-
-        return this.getEventData(eventName, {
-            filter,
-            fromBlock,
-            toBlock
-        })
+        this.events = new ContractEvent(this)
     }
 
     public getAddress(): string {

--- a/src/keeper/contracts/DIDRegistry.ts
+++ b/src/keeper/contracts/DIDRegistry.ts
@@ -247,7 +247,7 @@ export default class DIDRegistry extends ContractBase {
 
     public async getAttributesByOwner(owner: string): Promise<string[]> {
         return (
-            await this.getPastEvents('DIDAttributeRegistered', {
+            await this.events.getPastEvents('DIDAttributeRegistered', {
                 _owner: zeroX(owner)
             })
         )
@@ -315,7 +315,7 @@ export default class DIDRegistry extends ContractBase {
     // Provenance
     public async getDIDProvenanceEvents(did: string) {
         return (
-            await this.getPastEvents('ProvenanceAttributeRegistered', {
+            await this.events.getPastEvents('ProvenanceAttributeRegistered', {
                 _did: didZeroX(did)
             })
         )
@@ -346,7 +346,10 @@ export default class DIDRegistry extends ContractBase {
                 break
         }
         return (
-            await this.getPastEvents(capitalize(ProvenanceMethod[method as any]), filter)
+            await this.events.getPastEvents(
+                capitalize(ProvenanceMethod[method as any]),
+                filter
+            )
         ).map(({ returnValues }) => eventToObject(returnValues))
     }
 

--- a/src/keeper/contracts/conditions/AccessCondition.ts
+++ b/src/keeper/contracts/conditions/AccessCondition.ts
@@ -42,7 +42,7 @@ export class AccessCondition extends Condition {
         consumer: string
     ): Promise<{ did: string; agreementId: string }[]> {
         return (
-            await this.getPastEvents('Fulfilled', {
+            await this.events.getPastEvents('Fulfilled', {
                 _grantee: zeroX(consumer)
             })
         ).map(({ returnValues }) => ({

--- a/src/nevermined/AgreementsConditions.ts
+++ b/src/nevermined/AgreementsConditions.ts
@@ -185,7 +185,7 @@ export class AgreementsConditions extends Instantiable {
         providerPub: BabyjubPublicKey
     ) {
         const { accessProofCondition } = this.nevermined.keeper.conditions
-        const ev = await accessProofCondition.getPastEvents('Fulfilled', {
+        const ev = await accessProofCondition.events.getPastEvents('Fulfilled', {
             _agreementId: agreementId
         })
         const [cipherL, cipherR] = ev[0].returnValues._cipher

--- a/test/keeper/ContractBase.test.ts
+++ b/test/keeper/ContractBase.test.ts
@@ -61,7 +61,7 @@ describe('ContractWrapperBase', () => {
 
     describe('#getEventData()', () => {
         it('should fail on unknown event', done => {
-            wrappedContract.getEventData('crazyevent', {}).catch(() => {
+            wrappedContract.events.getEventData('crazyevent', {}).catch(() => {
                 done()
             })
         })


### PR DESCRIPTION
## Description

This is a small refactor to make it easier to integrate different event providers like the graph

Note that this introduces a breaking change in how we get the event data

Before:
```typescript
nevermined.keeper.didRegistry.getPastEvents(...)
nevermined.keeper.didRegistry.getEventData(...)
```
Now:
```typescript
nevermined.keeper.didRegistry.events.getPastEvents(...)
nevermined.keeper.didRegistry.events.getEventData(...)
```
The arguments are still the same.
Now all contracts contain an events field that right now is using JSON-RPC but in another pr it will add one for graph

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()