### PR TITLE
Added support for celo mainnet

### DIFF
--- a/src/keeper/Keeper.ts
+++ b/src/keeper/Keeper.ts
@@ -338,6 +338,8 @@ export class Keeper extends Instantiable {
                     return 'Nile'
                 case 0xcea11:
                     return 'Pacific'
+                case 42220:
+                    return 'celo'
                 case 44787:
                     return 'celo-alfajores'
                 case 62320:


### PR DESCRIPTION
## Description

Added support for celo mainnet. This assumes that the artifacts will use `celo`
as the network name.

Tests will need to be added after we have the celo artifacts

## Is this PR related with an open issue?

Related to Issue https://github.com/nevermined-io/internal/issues/185

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()
