### PR TITLE
[wip] stringify with bignumber

### DIFF
--- a/src/keeper/contracts/Dispenser.ts
+++ b/src/keeper/contracts/Dispenser.ts
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js'
 import ContractBase, { TxParameters } from './ContractBase'
 import { InstantiableConfig } from '../../Instantiable.abstract'
 
@@ -13,6 +14,6 @@ export default class Dispenser extends ContractBase {
         receiverAddress: string,
         params?: TxParameters
     ) {
-        return this.send('requestTokens', receiverAddress, [String(amount)], params)
+        return this.send('requestTokens', receiverAddress, [(new BigNumber(amount)).toString(10)], params)
     }
 }

--- a/src/keeper/contracts/conditions/LockPaymentCondition.ts
+++ b/src/keeper/contracts/conditions/LockPaymentCondition.ts
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js'
 import { Condition } from './Condition.abstract'
 import { didZeroX, zeroX } from '../../../utils'
 import { InstantiableConfig } from '../../../Instantiable.abstract'
@@ -18,7 +19,7 @@ export class LockPaymentCondition extends Condition {
         amounts: number[],
         receivers: string[]
     ) {
-        const amountsString = amounts.map(v => String(v))
+        const amountsString = amounts.map(v => (new BigNumber(v)).toString(10))
         return super.hashValues(
             didZeroX(did),
             zeroX(rewardAddress),
@@ -38,7 +39,7 @@ export class LockPaymentCondition extends Condition {
         from?: Account,
         params?: TxParameters
     ) {
-        const amountsString = amounts.map(v => String(v))
+        const amountsString = amounts.map(v => (new BigNumber(v)).toString(10))
         return super.fulfill(
             agreementId,
             [

--- a/src/nevermined/Accounts.ts
+++ b/src/nevermined/Accounts.ts
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js'
 import Balance from '../models/Balance'
 import Account from './Account'
 import { Instantiable, InstantiableConfig } from '../Instantiable.abstract'
@@ -53,7 +54,7 @@ export class Accounts extends Instantiable {
         params?: TxParameters
     ): Promise<boolean> {
         try {
-            await account.requestTokens(amount, params)
+            await account.requestTokens((new BigNumber(amount)).toString(10), params)
             return true
         } catch (e) {
             return false

--- a/test/keeper/conditions/LockPaymentCondition.test.ts
+++ b/test/keeper/conditions/LockPaymentCondition.test.ts
@@ -23,7 +23,7 @@ let buyer: Account
 let seller: Account
 
 describe('LockPaymentCondition', () => {
-    const amount = 15
+    const amount = 15e+4
     let agreementId
     let did
 
@@ -90,7 +90,7 @@ describe('LockPaymentCondition', () => {
             )
 
             await buyer.requestTokens(assetRewards.getTotalPrice())
-
+            console.log(await token.balanceOf(buyer.getId()), assetRewards.getTotalPrice())
             await token.approve(
                 lockPaymentCondition.getAddress(),
                 assetRewards.getTotalPrice(),


### PR DESCRIPTION
## Description

exponential amounts occur from 10e+21 (so 1000 tokens with 18 decimals)
they're not handled with BigNumber when sending to contract land
- [ ] need to test with amounts in exponential format (like 10e+21, tests will fail )
- [ ] stuck with requestTokens in tests 

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()