### PR TITLE
Add workflow for github releases

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -1,0 +1,53 @@
+name: GitHub Release
+
+on:
+  push:
+    tags:
+      - 'v*.*'
+
+jobs:
+  release:
+    name: "Tagged Release"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.API_TOKEN_GITHUB }}
+
+      # Build process
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '12.x'
+          cache: yarn
+
+      - name: Set version to env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
+
+      - name: Build package
+        run: |
+          npm pack
+
+      - name: Update CHANGELOG.md
+        id: changelog
+        run: |
+          yarn add --dev auto-changelog
+          npx auto-changelog
+
+      - name: Commit CHANGELOG.md
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Automated CHANGELOG.md update
+          commit_options: '--no-verify --signoff'
+          file_pattern: CHANGELOG.md
+          branch: master
+
+      - name: Publish Github relase
+        uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false
+          files: |
+            CHANGELOG.md
+            nevermined-io-nevermined-sdk-js-${{ env.RELEASE_VERSION }}.tgz


### PR DESCRIPTION
## Description

Add workflow for github releases. It includes the npm package in the release artifacts. If tag and version in package.json are not equal, the release will fail (as it won't be able to find the tgz to include in the release).

## Is this PR related with an open issue?

Related to Issue https://github.com/keyko-io/engineering/issues/50

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()