### PR TITLE
POC: Readable signature message

### DIFF
--- a/src/models/Config.ts
+++ b/src/models/Config.ts
@@ -88,6 +88,10 @@ export class Config {
      * The address receiving the fee if this is higher than 0
      */
     public feeReceiver?: string = ZeroAddress
+
+    public signatureMessage?: {
+        GenerateClientAssertion: (walletAddress: string) => string
+    }
 }
 
 export default Config


### PR DESCRIPTION
## Description

The goal is to customise signature messages:
<img width="1346" alt="Screenshot 2023-01-17 at 18 52 35" src="https://user-images.githubusercontent.com/1643399/212986573-d5e1993e-ff45-4596-b2b1-5414913fdba3.png">

This PR adds:
* Look for a custom message per type/function in the config (client app customises the messages);
* Sign a readable custom message and make it a JWT payload;

## Is this PR related with an open issue?

Related to Issue https://github.com/nevermined-io/one/issues/64

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation