### PR TITLE
Adding burn method for ERC-721 NFTs

### DIFF
--- a/integration/nevermined/NFT721.test.ts
+++ b/integration/nevermined/NFT721.test.ts
@@ -92,10 +92,12 @@ describe('Nfts721 operations', async () => {
             console.log(`NFT (ERC-721) clonned into address ${cloneAddress}`)
         })
 
-        it('should mint an nft token', async () => {
+        it('should mint and burn a nft token', async () => {
             // artist mints the nft
             const tokenId = generateId()            
             await nftContract.mint(zeroX(tokenId), artist.getId())
+
+            await nftContract.burn(zeroX(tokenId), artist)
         })
 
         it('should transfer an nft token with default token', async () => {

--- a/integration/nevermined/Subscriptions.e2e.test.ts
+++ b/integration/nevermined/Subscriptions.e2e.test.ts
@@ -126,7 +126,10 @@ describe('Subscriptions using NFT ERC-721 End-to-End', () => {
 
             await nevermined.contracts.loadNft721Api(subscriptionNFT)
 
-            subscriptionNFT.grantOperatorRole(transferNft721Condition.address, editor)
+            await subscriptionNFT.grantOperatorRole(transferNft721Condition.address, editor)
+
+            const isOperator = await subscriptionNFT.getContract.isOperator(transferNft721Condition.address)
+            assert.isTrue(isOperator)
 
             const nftAttributes = NFTAttributes.getSubscriptionInstance({
                 metadata: subscriptionMetadata,

--- a/src/keeper/contracts/Nft721Contract.ts
+++ b/src/keeper/contracts/Nft721Contract.ts
@@ -1,6 +1,6 @@
 import { TxParameters } from './ContractBase'
 import { InstantiableConfig } from '../../Instantiable.abstract'
-import { didZeroX } from '../../utils'
+import { didZeroX, zeroX } from '../../utils'
 import { Account } from '../../nevermined'
 import { ethers } from 'ethers'
 import { BigNumber } from '../../utils'
@@ -100,6 +100,23 @@ export class Nft721Contract extends NFTContractsBase {
     ) {
         return this.sendFrom('mint', [to, didZeroX(did), url], from, txParams)
     }
+
+    /**
+     * It burns some editions of a NFT (ERC-721)
+     *
+     * @param tokenId - The NFT id to burn
+     * @param from - The account burning the NFT
+     * @param txParams - Transaction additional parameters
+     * @returns Contract Receipt
+     */
+    public async burn(        
+        tokenId: string,
+        from?: Account,
+        txParams?: TxParameters
+    ) {
+        return this.sendFrom('burn', [zeroX(tokenId)], from, txParams)
+    }
+
 
     public async setApprovalForAll(
         target: string,

--- a/src/nevermined/api/nfts/NFT721Api.ts
+++ b/src/nevermined/api/nfts/NFT721Api.ts
@@ -310,6 +310,38 @@ export class NFT721Api extends NFTsBaseApi {
     }
 
     /**
+     * Burn NFTs associated with an asset.
+     *
+     * @remarks
+     * The publisher can only burn NFTs that it owns. NFTs that were already transferred cannot be burned by the publisher.
+     *
+     * @example
+     * ```ts
+     * await nevermined.nfts721.burn(
+     *           tokenId,     
+     *           artist
+     * )
+     * ```
+     *
+     * @param tokenId - The identifier of the token to burn
+     * @param account - The account of the publisher of the NFT.
+     * @param txParams - Optional transaction parameters.
+     *
+     * @returns The {@link ethers.ContractReceipt}
+     */
+    public async burn(
+        tokenId: string,        
+        account: Account,
+        txParams?: TxParameters
+    ) {
+        return await this.nftContract.burn(
+            tokenId,
+            account,
+            txParams
+        )        
+    }
+
+    /**
      * Mint NFTs associated with an asset allowing to specify some metadata
      *
      * This function can be called multiple times as long as the minting does not exceed the maximum cap set during creation.


### PR DESCRIPTION
## Description

Burn api was missing for ERC-721 NFTs

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()