### PR TITLE
feat: adds utility functions to manage unlisting and voting

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,7 +17,6 @@ jobs:
           opengsn: 'true'
           estuary: 'true'
           contracts-version: 'v3.0.0'
-          node-version: 'v1.1.4'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,7 +17,7 @@ jobs:
           opengsn: 'true'
           estuary: 'true'
           contracts-version: 'v3.0.0'
-          node-version: 'v1.0.0'
+          node-version: 'v1.1.4'
 
       - name: Install dependencies
         run: |

--- a/integration/nevermined/Assets.test.ts
+++ b/integration/nevermined/Assets.test.ts
@@ -1,5 +1,5 @@
 import { SearchQuery } from '../../src/common'
-import { assert } from 'chai'
+import { assert, expect } from 'chai'
 import { decodeJwt, JWTPayload } from 'jose'
 import { config } from '../config'
 import { getAssetPrice, getMetadata } from '../utils'
@@ -11,6 +11,7 @@ import { PublishMetadata, DIDResolvePolicy } from '../../src/nevermined'
 let nevermined: Nevermined
 let publisher: Account
 let metadata: MetaData
+let createdMetadata: MetaData
 let assetPrice: AssetPrice
 let payload: JWTPayload
 let ddo: DDO
@@ -25,6 +26,7 @@ describe('Assets', () => {
     const clientAssertion = await nevermined.utils.jwt.generateClientAssertion(publisher)
 
     await nevermined.services.marketplace.login(clientAssertion)
+
     payload = decodeJwt(config.marketplaceAuthToken)
     assetPrice = getAssetPrice(publisher.getId())
 
@@ -40,10 +42,13 @@ describe('Assets', () => {
   describe('#register()', () => {
     it('create with immutable data', async () => {
       const nonce = Math.random()
-      const immutableMetadata = getMetadata(nonce, `Immutable Test ${nonce}`)
+      createdMetadata = getMetadata(nonce, `Immutable Test ${nonce}`)
+
+      createdMetadata.main.ercType = 721
+      createdMetadata.additionalInformation.tags = ['test']
 
       const assetAttributes = AssetAttributes.getInstance({
-        metadata: immutableMetadata,
+        metadata: createdMetadata,
         price: assetPrice,
       })
       ddo = await nevermined.assets.create(assetAttributes, publisher, PublishMetadata.IPFS)
@@ -53,6 +58,10 @@ describe('Assets', () => {
       assert.isTrue(ddo._nvm.versions[0].immutableUrl.startsWith('cid://'))
       assert.isTrue(ddo._nvm.versions[0].immutableUrl.length > 10)
       assert.equal(ddo._nvm.versions[0].immutableBackend, 'ipfs')
+
+      const metadata = ddo.findServiceByType('metadata')
+      assert.equal(metadata.attributes.main.ercType, 721)
+      assert.equal(metadata.attributes.additionalInformation.tags[0], 'test')
     })
   })
 
@@ -89,7 +98,10 @@ describe('Assets', () => {
     it('update an existing asset', async () => {
       const nonce = Math.random()
       const name = `Updated Metadata Test ${nonce}`
-      const updatedMetadata = getMetadata(nonce, name)
+      const updatedMetadata = {
+        ...createdMetadata,
+        name,
+      }
 
       await nevermined.assets.update(
         ddo.shortId(),
@@ -103,10 +115,12 @@ describe('Assets', () => {
 
       const resolvedDDO = await nevermined.assets.resolve(ddo.id, DIDResolvePolicy.ImmutableFirst)
       assert.isDefined(resolvedDDO)
-      assert.equal(
-        updatedMetadata.main.name,
-        resolvedDDO.findServiceByType('metadata').attributes.main.name,
-      )
+
+      const metadata = resolvedDDO.findServiceByType('metadata')
+      assert.equal(metadata.attributes.main.ercType, 721)
+      assert.equal(metadata.attributes.additionalInformation.tags[0], 'test')
+
+      assert.equal(updatedMetadata.main.name, metadata.attributes.main.name)
 
       const metaApiDDO = await nevermined.assets.resolve(ddo.id, DIDResolvePolicy.OnlyMetadataAPI)
       assert.isDefined(metaApiDDO)
@@ -114,6 +128,53 @@ describe('Assets', () => {
         updatedMetadata.main.name,
         metaApiDDO.findServiceByType('metadata').attributes.main.name,
       )
+    })
+
+    it('unlist and list an asset', async () => {
+      // Unlisting Asset
+      await nevermined.assets.switchListing(ddo.shortId(), false, publisher)
+      // Waiting to metadata to be updated and propagated
+      await sleep(3000)
+      let resolvedDDO = await nevermined.assets.resolve(ddo.id, DIDResolvePolicy.ImmutableFirst)
+      assert.isDefined(resolvedDDO)
+      let metadata = resolvedDDO.findServiceByType('metadata')
+      assert.equal(metadata.attributes.curation.isListed, false)
+
+      // Listing Asset back
+      await nevermined.assets.switchListing(ddo.shortId(), true, publisher)
+      // Waiting to metadata to be updated and propagated
+      await sleep(3000)
+      resolvedDDO = await nevermined.assets.resolve(ddo.id, DIDResolvePolicy.ImmutableFirst)
+      assert.isDefined(resolvedDDO)
+      metadata = resolvedDDO.findServiceByType('metadata')
+      assert.equal(metadata.attributes.curation.isListed, true)
+    })
+
+    it('add a vote', async () => {
+      // Adding some votes
+      await nevermined.assets.addRating(ddo.shortId(), 0.5, 1, publisher)
+      // Waiting to metadata to be updated and propagated
+      await sleep(3000)
+      let resolvedDDO = await nevermined.assets.resolve(ddo.id, DIDResolvePolicy.ImmutableFirst)
+      assert.isDefined(resolvedDDO)
+      let metadata = resolvedDDO.findServiceByType('metadata')
+      assert.equal(metadata.attributes.curation.rating, 0.5)
+      assert.equal(metadata.attributes.curation.numVotes, 1)
+
+      // More votes
+      await nevermined.assets.addRating(ddo.shortId(), 0.4, 2, publisher)
+      // Waiting to metadata to be updated and propagated
+      await sleep(3000)
+      resolvedDDO = await nevermined.assets.resolve(ddo.id, DIDResolvePolicy.ImmutableFirst)
+      assert.isDefined(resolvedDDO)
+      metadata = resolvedDDO.findServiceByType('metadata')
+      assert.equal(metadata.attributes.curation.rating, 0.4)
+      assert.equal(metadata.attributes.curation.numVotes, 1 + 2)
+    })
+
+    it('new rating must be between 0 and 1', async () => {
+      // Trying to add a vote with a rating out of range
+      await assert.isRejected(nevermined.assets.addRating(ddo.shortId(), 2, 1, publisher))
     })
   })
 
@@ -140,6 +201,14 @@ describe('Assets', () => {
       const assets = await nevermined.search.byText(text)
 
       assert.isDefined(assets)
+    })
+  })
+
+  describe('#retire()', () => {
+    it.skip('retire an existing asset', async () => {
+      await nevermined.assets.retire(ddo.id)
+      await sleep(3000)
+      await expect(await nevermined.assets.resolve(ddo.id)).to.be.rejectedWith(Error)
     })
   })
 

--- a/integration/nevermined/Assets.test.ts
+++ b/integration/nevermined/Assets.test.ts
@@ -132,7 +132,7 @@ describe('Assets', () => {
 
     it('unlist and list an asset', async () => {
       // Unlisting Asset
-      await nevermined.assets.switchListing(ddo.shortId(), false, publisher)
+      await nevermined.assets.list(ddo.shortId(), false, publisher)
       // Waiting to metadata to be updated and propagated
       await sleep(3000)
       let resolvedDDO = await nevermined.assets.resolve(ddo.id, DIDResolvePolicy.ImmutableFirst)
@@ -141,7 +141,7 @@ describe('Assets', () => {
       assert.equal(metadata.attributes.curation.isListed, false)
 
       // Listing Asset back
-      await nevermined.assets.switchListing(ddo.shortId(), true, publisher)
+      await nevermined.assets.list(ddo.shortId(), true, publisher)
       // Waiting to metadata to be updated and propagated
       await sleep(3000)
       resolvedDDO = await nevermined.assets.resolve(ddo.id, DIDResolvePolicy.ImmutableFirst)

--- a/integration/nevermined/DDO.test.ts
+++ b/integration/nevermined/DDO.test.ts
@@ -65,6 +65,11 @@ describe('DDO Tests', () => {
         description: 'Nevermined is an ecosystem development platform.',
         customData: {},
       },
+      curation: {
+        isListed: true,
+        numVotes: 0,
+        rating: 0,
+      },
     }
 
     const assetAttributes = AssetAttributes.getInstance({
@@ -75,6 +80,7 @@ describe('DDO Tests', () => {
 
     const ddo = await nevermined.assets.create(assetAttributes, publisher)
 
+    console.log(ddo.id)
     assert.deepEqualExcludingEvery(
       metadata,
       metadataDataset as MetaData,
@@ -242,7 +248,14 @@ describe('DDO Tests', () => {
         datePublished: '2023-01-01T00:00:00Z',
         author: 'root@nevermined.io',
         license: 'Apache License 2.0',
-        files: [],
+        files: [
+          {
+            index: 0,
+            contentType: 'text/markdown',
+            url: 'https://raw.githubusercontent.com/nevermined-io/.github/master/profile/README.md',
+            checksum: generateId(),
+          },
+        ],
         workflow: {
           coordinationType: 'argo',
           stages: [
@@ -270,6 +283,11 @@ describe('DDO Tests', () => {
       additionalInformation: {
         description: 'Nevermined is an ecosystem development platform.',
         customData: {},
+      },
+      curation: {
+        isListed: true,
+        numVotes: 0,
+        rating: 0,
       },
     }
 

--- a/integration/resources/ddo-algorithm.json
+++ b/integration/resources/ddo-algorithm.json
@@ -22,6 +22,7 @@
       "serviceEndpoint": "http://marketplace.nevermined.localnet/api/v1/metadata/assets/ddo/did:nv:9b695884eea8bea44141a7517bd8120f497dc507aeeded39c87077f288c0d1ea",
       "attributes": {
         "curation": {
+          "isListed": true,
           "rating": 0,
           "numVotes": 0
         },

--- a/integration/resources/ddo-compute.json
+++ b/integration/resources/ddo-compute.json
@@ -22,6 +22,7 @@
       "serviceEndpoint": "http://marketplace.nevermined.localnet/api/v1/metadata/assets/ddo/did:nv:04b5c4a2cdee6318d6b351260bc07817034e33a52b31a8e94598d472b933557c",
       "attributes": {
         "curation": {
+          "isListed": true,
           "rating": 0,
           "numVotes": 0
         },

--- a/integration/resources/ddo-dataset.json
+++ b/integration/resources/ddo-dataset.json
@@ -22,6 +22,7 @@
       "serviceEndpoint": "http://marketplace.nevermined.localnet/api/v1/metadata/assets/ddo/did:nv:7c15b3449af541258f4f098a6444a8f15c98e9721db57fc4a02f2922521bd4a3",
       "attributes": {
         "curation": {
+          "isListed": true,
           "rating": 0,
           "numVotes": 0
         },

--- a/integration/resources/ddo-nft.json
+++ b/integration/resources/ddo-nft.json
@@ -22,6 +22,7 @@
       "serviceEndpoint": "http://nevermined-metadata:3100/api/v1/metadata/assets/ddo/did:nv:888e35d123632e6d77ef5692bdf4fe92a17c693c62d2d4e3408853c6f0a74f15",
       "attributes": {
         "curation": {
+          "isListed": true,
           "rating": 0,
           "numVotes": 0
         },

--- a/integration/resources/ddo-workflow.json
+++ b/integration/resources/ddo-workflow.json
@@ -22,6 +22,7 @@
       "serviceEndpoint": "http://marketplace.nevermined.localnet/api/v1/metadata/assets/ddo/did:nv:c7fe6187190e4282709251c38265226a374bc19aefade8c759fb5ccc05bfb101",
       "attributes": {
         "curation": {
+          "isListed": true,
           "rating": 0,
           "numVotes": 0
         },
@@ -33,7 +34,12 @@
           "datePublished": "2023-01-01T00:00:00Z",
           "author": "root@nevermined.io",
           "license": "Apache License 2.0",
-          "files": [],
+          "files": [
+            {
+              "index": 0,
+              "contentType": "text/markdown"
+            }
+          ],
           "workflow": {
             "coordinationType": "argo",
             "stages": [

--- a/integration/resources/metadata-dataset.json
+++ b/integration/resources/metadata-dataset.json
@@ -18,5 +18,10 @@
   "additionalInformation": {
     "description": "Nevermined is an ecosystem development platform.",
     "customData": {}
+  },
+  "curation": {
+    "isListed": true,
+    "numVotes": 0,
+    "rating": 0
   }
 }

--- a/integration/resources/metadata-workflow.json
+++ b/integration/resources/metadata-workflow.json
@@ -6,7 +6,14 @@
     "datePublished": "2023-01-01T00:00:00Z",
     "author": "root@nevermined.io",
     "license": "Apache License 2.0",
-    "files": [],
+    "files": [
+      {
+        "index": 0,
+        "contentType": "text/markdown",
+        "url": "https://raw.githubusercontent.com/nevermined-io/.github/master/profile/README.md",
+        "checksum": "85ccecc5352d4e38840ad5047ca019fc88e8e30c9f704e78b345eeecb1504569"
+      }
+    ],
     "workflow": {
       "coordinationType": "argo",
       "stages": [
@@ -34,5 +41,10 @@
   "additionalInformation": {
     "description": "Nevermined is an ecosystem development platform.",
     "customData": {}
+  },
+  "curation": {
+    "isListed": true,
+    "numVotes": 0,
+    "rating": 0
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nevermined-io/sdk",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Javascript SDK for connecting with Nevermined Data Platform ",
   "main": "./dist/node/sdk.js",
   "typings": "./dist/node/sdk.d.ts",

--- a/src/nevermined/api/RegistryBaseApi.ts
+++ b/src/nevermined/api/RegistryBaseApi.ts
@@ -438,7 +438,7 @@ export abstract class RegistryBaseApi extends Instantiable {
    * @param txParams - Optional transaction parameters
    * @returns {@link DDO} The DDO updated
    */
-  public switchListing(
+  public list(
     did: string,
     list: boolean,
     publisher: Account,

--- a/src/nevermined/api/RegistryBaseApi.ts
+++ b/src/nevermined/api/RegistryBaseApi.ts
@@ -180,6 +180,7 @@ export abstract class RegistryBaseApi extends Instantiable {
         attributes: {
           // Default values
           curation: {
+            isListed: true,
             rating: 0,
             numVotes: 0,
           },
@@ -309,18 +310,37 @@ export abstract class RegistryBaseApi extends Instantiable {
   }
 
   /**
-   * Initialities the default Nevermined service plugins and return that instance
-   * @param config Nevermined config
-   * @returns The Nevermined Service Plugin instance
+   * Returns a DDO by DID. Depending of the resolution policy it prioritize the Metadata API or Immutable urls.
+   * @param did - Decentralized ID.
+   * @param policy - It specifies the resolve policy to apply. It allows to select that priorities during the asset resolution via Metadata API or Immutable URLs (IPFS, Filecoin, etc)
+   * @returns {@link DDO}
    */
-  protected static getServicePlugin(config: InstantiableConfig) {
-    return {
-      access: new AccessService(config, config.nevermined.keeper.templates.accessTemplate),
-      compute: config.nevermined.keeper.templates.escrowComputeExecutionTemplate,
-      'nft-sales': new NFTSalesService(config),
-      'nft-access': new NFTAccessService(config),
-      'aave-credit': config.nevermined.keeper.templates
-        .aaveCreditTemplate as ServicePlugin<ServiceAaveCredit>,
+  protected async resolveAsset(
+    did: string,
+    policy: DIDResolvePolicy = DIDResolvePolicy.ImmutableFirst,
+  ): Promise<DDO> {
+    const { serviceEndpoint, immutableUrl } =
+      await this.nevermined.keeper.didRegistry.getAttributesByDid(did)
+
+    if (policy === DIDResolvePolicy.OnlyImmutable)
+      return await this.nevermined.services.metadata.retrieveDDOFromImmutableBackend(immutableUrl)
+    else if (policy === DIDResolvePolicy.OnlyMetadataAPI)
+      return await this.nevermined.services.metadata.retrieveDDOByUrl(serviceEndpoint)
+    else if (policy === DIDResolvePolicy.ImmutableFirst) {
+      try {
+        return await this.nevermined.services.metadata.retrieveDDOFromImmutableBackend(immutableUrl)
+      } catch (error) {
+        this.logger.debug(`Unable to fetch DDO from immutable data store`)
+      }
+      return await this.nevermined.services.metadata.retrieveDDOByUrl(serviceEndpoint)
+    } else {
+      // DIDResolvePolicy.MetadataAPIFirst
+      try {
+        return await this.nevermined.services.metadata.retrieveDDOByUrl(serviceEndpoint)
+      } catch (error) {
+        this.logger.debug(`Unable to fetch DDO metadata api`)
+      }
+      return await this.nevermined.services.metadata.retrieveDDOFromImmutableBackend(immutableUrl)
     }
   }
 
@@ -346,10 +366,17 @@ export abstract class RegistryBaseApi extends Instantiable {
       const ddo = await this.resolveAsset(did)
 
       observer.next(UpdateProgressStep.UpdateMetadataInDDO)
-      const metadataService = ddo.findServiceByType('metadata')
+      let metadataService = ddo.findServiceByType('metadata')
 
-      metadataService.attributes.additionalInformation = metadata.additionalInformation
-      metadataService.attributes.main = metadata.main
+      metadataService = {
+        ...metadataService,
+        attributes: {
+          ...metadataService.attributes,
+          main: metadata.main,
+          additionalInformation: metadata.additionalInformation,
+          curation: metadata.curation,
+        },
+      }
 
       await ddo.replaceService(metadataService.index, metadataService)
 
@@ -401,38 +428,105 @@ export abstract class RegistryBaseApi extends Instantiable {
   }
 
   /**
-   * Returns a DDO by DID. Depending of the resolution policy it prioritize the Metadata API or Immutable urls.
-   * @param did - Decentralized ID.
-   * @param policy - It specifies the resolve policy to apply. It allows to select that priorities during the asset resolution via Metadata API or Immutable URLs (IPFS, Filecoin, etc)
-   * @returns {@link DDO}
+   * Given a DID, updates the metadata associated to the asset allowing to list or unlist it. It also can upload this metadata to a remote decentralized stored depending on the `publishMetadata` parameter.
+   * In a Nevermined environment, when an asset is unlisted, it is not possible to be found and accessed by any user.
+   *
+   * @param did - Decentralized ID representing the unique id of an asset in a Nevermined network.
+   * @param list - Needs the asset to be listed or unlisted
+   * @param publisher - Account of the user updating the metadata
+   * @param publishMetadata - It allows to specify where to store the metadata
+   * @param txParams - Optional transaction parameters
+   * @returns {@link DDO} The DDO updated
    */
-  protected async resolveAsset(
+  public switchListing(
     did: string,
-    policy: DIDResolvePolicy = DIDResolvePolicy.ImmutableFirst,
-  ): Promise<DDO> {
-    const { serviceEndpoint, immutableUrl } =
-      await this.nevermined.keeper.didRegistry.getAttributesByDid(did)
+    list: boolean,
+    publisher: Account,
+    publishMetadata: PublishMetadata = PublishMetadata.OnlyMetadataAPI,
+    txParams?: TxParameters,
+  ): SubscribablePromise<UpdateProgressStep, DDO> {
+    this.logger.log('Switching Asset Publication')
+    return new SubscribablePromise(async (observer) => {
+      observer.next(UpdateProgressStep.ResolveAsset)
+      const ddo = await this.resolveAsset(did)
 
-    if (policy === DIDResolvePolicy.OnlyImmutable)
-      return await this.nevermined.services.metadata.retrieveDDOFromImmutableBackend(immutableUrl)
-    else if (policy === DIDResolvePolicy.OnlyMetadataAPI)
-      return await this.nevermined.services.metadata.retrieveDDOByUrl(serviceEndpoint)
-    else if (policy === DIDResolvePolicy.ImmutableFirst) {
-      try {
-        return await this.nevermined.services.metadata.retrieveDDOFromImmutableBackend(immutableUrl)
-      } catch (error) {
-        this.logger.debug(`Unable to fetch DDO from immutable data store`)
+      const metadataService = ddo.findServiceByType('metadata')
+      if (!metadataService.attributes.curation) {
+        metadataService.attributes.curation = {
+          isListed: list,
+          rating: 0,
+          numVotes: 0,
+        }
+      } else if (
+        metadataService.attributes.curation.isListed &&
+        metadataService.attributes.curation.isListed === list
+      ) {
+        this.logger.log('Asset was already having the same listing status')
+        return ddo
       }
-      return await this.nevermined.services.metadata.retrieveDDOByUrl(serviceEndpoint)
-    } else {
-      // DIDResolvePolicy.MetadataAPIFirst
-      try {
-        return await this.nevermined.services.metadata.retrieveDDOByUrl(serviceEndpoint)
-      } catch (error) {
-        this.logger.debug(`Unable to fetch DDO metadata api`)
+
+      metadataService.attributes.curation = {
+        ...metadataService.attributes.curation,
+        isListed: list,
       }
-      return await this.nevermined.services.metadata.retrieveDDOFromImmutableBackend(immutableUrl)
-    }
+      return await this.updateAsset(
+        did,
+        metadataService.attributes,
+        publisher,
+        publishMetadata,
+        txParams,
+      )
+    })
+  }
+
+  /**
+   * Given a DID, it adds a vote to the asset curation information.
+   *
+   * @param did - Decentralized ID representing the unique id of an asset in a Nevermined network.
+   * @param newRating - New average rating of the asset
+   * @param numVotesAdded - Number of new votes added to the rating, typically just 1
+   * @param publisher - Account of the user updating the metadata
+   * @param publishMetadata - It allows to specify where to store the metadata
+   * @param txParams - Optional transaction parameters
+   * @returns {@link DDO} The DDO updated
+   */
+  public addRating(
+    did: string,
+    newRating: number,
+    numVotesAdded = 1,
+    publisher: Account,
+    publishMetadata: PublishMetadata = PublishMetadata.OnlyMetadataAPI,
+    txParams?: TxParameters,
+  ): SubscribablePromise<UpdateProgressStep, DDO> {
+    this.logger.log('Adding votes to the asset')
+    return new SubscribablePromise(async (observer) => {
+      if (newRating < 0 || newRating > 1) throw new Error('Rating must be between 0 and 1')
+
+      observer.next(UpdateProgressStep.ResolveAsset)
+      const ddo = await this.resolveAsset(did)
+
+      const metadataService = ddo.findServiceByType('metadata')
+      if (!metadataService.attributes.curation) {
+        metadataService.attributes.curation = {
+          isListed: true,
+          rating: newRating,
+          numVotes: numVotesAdded,
+        }
+      }
+
+      metadataService.attributes.curation = {
+        ...metadataService.attributes.curation,
+        rating: newRating,
+        numVotes: metadataService.attributes.curation.numVotes + numVotesAdded,
+      }
+      return await this.updateAsset(
+        did,
+        metadataService.attributes,
+        publisher,
+        publishMetadata,
+        txParams,
+      )
+    })
   }
 
   /**
@@ -477,5 +571,21 @@ export abstract class RegistryBaseApi extends Instantiable {
 
       return agreementId
     })
+  }
+
+  /**
+   * Initialities the default Nevermined service plugins and return that instance
+   * @param config Nevermined config
+   * @returns The Nevermined Service Plugin instance
+   */
+  protected static getServicePlugin(config: InstantiableConfig) {
+    return {
+      access: new AccessService(config, config.nevermined.keeper.templates.accessTemplate),
+      compute: config.nevermined.keeper.templates.escrowComputeExecutionTemplate,
+      'nft-sales': new NFTSalesService(config),
+      'nft-access': new NFTAccessService(config),
+      'aave-credit': config.nevermined.keeper.templates
+        .aaveCreditTemplate as ServicePlugin<ServiceAaveCredit>,
+    }
   }
 }


### PR DESCRIPTION
## Description

This PR includes:

- Add an assets method allowing to list/unlist an asset updating the metadata: `assets.list`
- Add an assets method allowing to add votes to the curation metadata: `assets.addRating`
- Fixes the update method that was missing some metadata parameters after an update
- Setup the `isListed` parameter is true by default during the assets registration

## Is this PR related with an open issue?

Related to Issue #485 

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] Follows the code style of this project.
- [X] Tests Cover Changes
- [X] Documentation

