### PR TITLE
Allowing to define timelock and timeout parameters

### DIFF
--- a/integration/nevermined/ClaimPaymentAbortedAgreement.test.ts
+++ b/integration/nevermined/ClaimPaymentAbortedAgreement.test.ts
@@ -80,7 +80,7 @@ describe('NFTs721 Api End-to-End', () => {
     metadata.userId = payload.sub
 
     // conditions
-    ;({ escrowPaymentCondition, transferNft721Condition } = nevermined.keeper.conditions)
+    ;({ transferNft721Condition } = nevermined.keeper.conditions)
 
     // components
     ;({ token } = nevermined.keeper)

--- a/integration/nevermined/ClaimPaymentAbortedAgreement.test.ts
+++ b/integration/nevermined/ClaimPaymentAbortedAgreement.test.ts
@@ -1,0 +1,326 @@
+import { assert } from 'chai'
+import { decodeJwt, JWTPayload } from 'jose'
+import { Account, DDO, Nevermined, NFTAttributes, AssetPrice } from '../../src'
+import { TransferNFT721Condition, Token, Nft721Contract, ConditionState } from '../../src/keeper'
+import { config } from '../config'
+import { getMetadata } from '../utils'
+import TestContractHandler from '../../test/keeper/TestContractHandler'
+import { ethers } from 'ethers'
+import { BigNumber } from '../../src/utils'
+import '../globals'
+import { mineBlocks } from '../utils/utils'
+
+describe('NFTs721 Api End-to-End', () => {
+  let publisher: Account
+  let collector1: Account
+  let other: Account
+
+  let nevermined: Nevermined
+  let token: Token
+  let transferNft721Condition: TransferNFT721Condition
+  let ddo: DDO
+
+  const metadata = getMetadata()
+  let agreementId: string
+
+  // Configuration of First Sale:
+  // Publisher -> Collector1, other account get a cut (25%)
+  let nftPrice = BigNumber.from(20)
+  let amounts = [BigNumber.from(15), BigNumber.from(5)]
+  let receivers: string[]
+  let assetPrice1: AssetPrice
+
+  let scale: BigNumber
+  let neverminedNodeAddress
+
+  let nft: ethers.Contract
+  let nftContract: Nft721Contract
+
+  let payload: JWTPayload
+
+  const fullfillAccessTimeout = 10
+  const fullfillAccessTimelock = 3
+
+  before(async () => {
+    nevermined = await Nevermined.getInstance(config)
+    ;[, publisher, collector1, , other] = await nevermined.accounts.list()
+
+    TestContractHandler.setConfig(config)
+
+    const networkName = (await nevermined.keeper.getNetworkName()).toLowerCase()
+    const erc721ABI = await TestContractHandler.getABI(
+      'NFT721Upgradeable',
+      config.artifactsFolder,
+      networkName,
+    )
+
+    nft = await TestContractHandler.deployArtifact(erc721ABI, publisher.getId(), [
+      publisher.getId(),
+      nevermined.keeper.didRegistry.address,
+      'NFT721',
+      'NVM',
+      '',
+      0,
+    ])
+
+    nftContract = await Nft721Contract.getInstance(
+      (nevermined.keeper as any).instanceConfig,
+      nft.address,
+    )
+
+    await nevermined.contracts.loadNft721(nftContract.address)
+
+    const clientAssertion = await nevermined.utils.jwt.generateClientAssertion(publisher)
+
+    await nevermined.services.marketplace.login(clientAssertion)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    payload = decodeJwt(config.marketplaceAuthToken!)
+    neverminedNodeAddress = await nevermined.services.node.getProviderAddress()
+
+    metadata.userId = payload.sub
+
+    // conditions
+    ;({ escrowPaymentCondition, transferNft721Condition } = nevermined.keeper.conditions)
+
+    // components
+    ;({ token } = nevermined.keeper)
+
+    scale = BigNumber.from(10).pow(await token.decimals())
+
+    nftPrice = nftPrice.mul(scale)
+    amounts = amounts.map((v) => v.mul(scale))
+    receivers = [publisher.getId(), other.getId()]
+    assetPrice1 = new AssetPrice(
+      new Map([
+        [receivers[0], amounts[0]],
+        [receivers[1], amounts[1]],
+      ]),
+    )
+
+    await nftContract.grantOperatorRole(transferNft721Condition.address, publisher)
+    await collector1.requestTokens(nftPrice.div(scale).mul(10))
+  })
+
+  describe('As a publisher I want to register a new asset', () => {
+    it('I want to register a new asset and tokenize (via NFT). The sales agreement expires in a few blocks', async () => {
+      const nftAttributes = NFTAttributes.getNFT721Instance({
+        metadata,
+        price: assetPrice1,
+        providers: [neverminedNodeAddress],
+        serviceTypes: ['nft-sales', 'nft-access'],
+        nftContractAddress: nftContract.address,
+        fulfillAccessTimeout: fullfillAccessTimeout,
+        fulfillAccessTimelock: fullfillAccessTimelock,
+      })
+      ddo = await nevermined.nfts721.create(nftAttributes, publisher)
+
+      assert.isDefined(ddo)
+
+      // Timeout & Timelock should only be set for the access condition
+      assert.equal(
+        ddo.findServiceByType('nft-sales').attributes.serviceAgreementTemplate?.conditions[0]
+          .timeout,
+        0,
+      )
+      assert.equal(
+        ddo.findServiceByType('nft-sales').attributes.serviceAgreementTemplate?.conditions[1]
+          .timeout,
+        fullfillAccessTimeout,
+      )
+      assert.equal(
+        ddo.findServiceByType('nft-sales').attributes.serviceAgreementTemplate?.conditions[0]
+          .timeout,
+        0,
+      )
+      assert.equal(
+        ddo.findServiceByType('nft-sales').attributes.serviceAgreementTemplate?.conditions[1]
+          .timelock,
+        fullfillAccessTimelock,
+      )
+
+      // Timeout & Timelock should not affect access services
+      assert.equal(
+        ddo.findServiceByType('nft-access').attributes.serviceAgreementTemplate?.conditions[0]
+          .timeout,
+        0,
+      )
+      assert.equal(
+        ddo.findServiceByType('nft-access').attributes.serviceAgreementTemplate?.conditions[1]
+          .timeout,
+        0,
+      )
+      assert.equal(
+        ddo.findServiceByType('nft-access').attributes.serviceAgreementTemplate?.conditions[0]
+          .timeout,
+        0,
+      )
+      assert.equal(
+        ddo.findServiceByType('nft-access').attributes.serviceAgreementTemplate?.conditions[1]
+          .timelock,
+        0,
+      )
+    })
+  })
+
+  describe('As a user I want to buy a NFT with a timelock', () => {
+    it('I can not order the NFT until timelock happens', async () => {
+      const collector1BalanceBefore = await token.balanceOf(collector1.getId())
+
+      agreementId = await nevermined.nfts721.order(ddo.id, collector1)
+      assert.isDefined(agreementId)
+
+      const agreement = await nevermined.agreements.getAgreement(agreementId)
+
+      // Transfer NFT Condition must be Time Locked
+      assert.isFalse(
+        await nevermined.keeper.conditionStoreManager.isConditionTimeLocked(
+          agreement.conditionIds[0],
+        ),
+      )
+      assert.isTrue(
+        await nevermined.keeper.conditionStoreManager.isConditionTimeLocked(
+          agreement.conditionIds[1],
+        ),
+      )
+      assert.isFalse(
+        await nevermined.keeper.conditionStoreManager.isConditionTimeLocked(
+          agreement.conditionIds[2],
+        ),
+      )
+
+      try {
+        assert.isTrue(
+          !(await nevermined.nfts721.claim(agreementId, publisher.getId(), collector1.getId())),
+        )
+      } catch (error) {
+        console.debug(`Unable to fullfill condition because timelock`)
+      }
+      const agreementStatusAfter =
+        await nevermined.keeper.templates.nftSalesTemplate.getAgreementStatus(agreementId)
+
+      assert.equal(agreementStatusAfter['lockPayment'].state, ConditionState.Fulfilled)
+      assert.equal(agreementStatusAfter['transferNFT'].state, ConditionState.Unfulfilled)
+      assert.equal(agreementStatusAfter['escrowPayment'].state, ConditionState.Unfulfilled)
+
+      const collector1BalanceAfter = await token.balanceOf(collector1.getId())
+
+      assert.isTrue(collector1BalanceAfter.add(nftPrice).eq(collector1BalanceBefore))
+    })
+
+    it('I can order the NFT after the timelock', async () => {
+      await mineBlocks(nevermined, collector1, fullfillAccessTimelock + 1)
+
+      const publisherBalanceBefore = await token.balanceOf(publisher.getId())
+      const collector1BalanceBefore = await token.balanceOf(collector1.getId())
+
+      const agreement = await nevermined.agreements.getAgreement(agreementId)
+
+      // Time Lock expired
+      assert.isFalse(
+        await nevermined.keeper.conditionStoreManager.isConditionTimeLocked(
+          agreement.conditionIds[0],
+        ),
+      )
+      assert.isFalse(
+        await nevermined.keeper.conditionStoreManager.isConditionTimeLocked(
+          agreement.conditionIds[1],
+        ),
+      )
+      assert.isFalse(
+        await nevermined.keeper.conditionStoreManager.isConditionTimeLocked(
+          agreement.conditionIds[2],
+        ),
+      )
+
+      // Transfer NFT Condition is not timed out
+      assert.isFalse(
+        await nevermined.keeper.conditionStoreManager.isConditionTimedOut(
+          agreement.conditionIds[1],
+        ),
+      )
+
+      await nevermined.nfts721.claim(agreementId, publisher.getId(), collector1.getId())
+
+      const agreementStatusAfter =
+        await nevermined.keeper.templates.nftSalesTemplate.getAgreementStatus(agreementId)
+
+      assert.equal(agreementStatusAfter['lockPayment'].state, ConditionState.Fulfilled)
+      assert.equal(agreementStatusAfter['transferNFT'].state, ConditionState.Fulfilled)
+      assert.equal(agreementStatusAfter['escrowPayment'].state, ConditionState.Fulfilled)
+
+      const publisherBalanceAfter = await token.balanceOf(publisher.getId())
+      const collector1BalanceAfter = await token.balanceOf(collector1.getId())
+
+      assert.isTrue(collector1BalanceBefore.eq(collector1BalanceAfter))
+      assert.isTrue(publisherBalanceBefore.add(amounts[0]).eq(publisherBalanceAfter))
+    })
+  })
+
+  describe('As a user I want to buy a NFT with a timeout', () => {
+    it('I can not get the NFT after timeout so I claim back my funds', async () => {
+      const collector1BalanceBeforeOrder = await token.balanceOf(collector1.getId())
+
+      agreementId = await nevermined.nfts721.order(ddo.id, collector1)
+      const agreement = await nevermined.agreements.getAgreement(agreementId)
+
+      assert.isFalse(
+        await nevermined.keeper.conditionStoreManager.isConditionTimedOut(
+          agreement.conditionIds[1],
+        ),
+      )
+
+      const collector1BalanceAfter = await token.balanceOf(collector1.getId())
+      assert.isTrue(collector1BalanceBeforeOrder.sub(nftPrice).eq(collector1BalanceAfter))
+
+      await mineBlocks(nevermined, collector1, fullfillAccessTimeout + 1)
+
+      try {
+        assert.isTrue(
+          !(await nevermined.nfts721.claim(agreementId, publisher.getId(), collector1.getId())),
+        )
+      } catch (error) {
+        console.debug(`Unable to fullfill condition because timeout`)
+      }
+
+      // Condition is timed out so the collector aborts it and gets the escrowed amount
+      await nevermined.keeper.conditions.transferNft721Condition.abortByTimeOut(
+        agreement.conditionIds[1],
+        collector1,
+      )
+      const agreementStatusAfter =
+        await nevermined.keeper.templates.nftSalesTemplate.getAgreementStatus(agreementId)
+
+      assert.equal(agreementStatusAfter['lockPayment'].state, ConditionState.Fulfilled)
+      assert.equal(agreementStatusAfter['transferNFT'].state, ConditionState.Aborted)
+      assert.equal(agreementStatusAfter['escrowPayment'].state, ConditionState.Unfulfilled)
+
+      assert.isTrue(await nevermined.nfts721.releaseRewards(agreementId, ddo.id, collector1))
+
+      const agreementStatusReleased =
+        await nevermined.keeper.templates.nftSalesTemplate.getAgreementStatus(agreementId)
+
+      assert.equal(agreementStatusReleased['lockPayment'].state, ConditionState.Fulfilled)
+      assert.equal(agreementStatusReleased['transferNFT'].state, ConditionState.Aborted)
+      assert.equal(agreementStatusReleased['escrowPayment'].state, ConditionState.Fulfilled)
+
+      const collector1BalanceReleased = await token.balanceOf(collector1.getId())
+      assert.isTrue(collector1BalanceBeforeOrder.eq(collector1BalanceReleased))
+    })
+  })
+
+  /**
+ * 
+    it.skip('Because the conditions timedout I want my money back', async () => {
+      // TODO: wait for timeout
+
+      const collector1BalanceBefore = await token.balanceOf(collector1.getId())      
+
+      // TODO: Abort the Condition
+      // TODO: Call the EscrowPayment condition
+
+
+      const collector1BalanceAfter = await token.balanceOf(collector1.getId())
+      assert.isTrue(collector1BalanceBefore.add(nftPrice).eq(collector1BalanceAfter))
+    })
+ */
+})

--- a/integration/nevermined/NFT721.test.ts
+++ b/integration/nevermined/NFT721.test.ts
@@ -78,6 +78,7 @@ describe('Nfts721 operations', async () => {
         serviceTypes: ['nft-sales', 'nft-access'],
         nftContractAddress: nft.address,
       })
+      assert.equal(nftAttributes.fulfillAccessTimelock, 0)
       ddo = await nevermined.nfts721.create(nftAttributes, artist)
     })
 

--- a/integration/nevermined/SecondaryMarket.test.ts
+++ b/integration/nevermined/SecondaryMarket.test.ts
@@ -360,6 +360,7 @@ describe('Secondary Markets', () => {
           await nftSalesTemplate.getServiceAgreementTemplateConditions()
 
         nftSalesServiceAgreementTemplate.conditions = fillConditionsWithDDO(
+          'nft-sales',
           nftSalesTemplateConditions,
           ddo,
           assetPrice2,

--- a/integration/utils/utils.ts
+++ b/integration/utils/utils.ts
@@ -1,4 +1,5 @@
-import { Logger } from '../../src'
+import { ethers } from 'ethers'
+import { Account, Logger, Nevermined, generateId } from '../../src'
 
 export const transformMetadata = (metadata: any): any => {
   try {
@@ -21,4 +22,18 @@ export async function repeat<T>(n: number, p: Promise<T>): Promise<T> {
     await sleep(500)
   }
   return p
+}
+
+export async function mineBlocks(nevermined: Nevermined, account: Account, blocksToWait: number) {
+  for (let index = 0; index < blocksToWait; index++) {
+    await nevermined.provenance.used(
+      generateId(),
+      generateId(),
+      account.getId(),
+      account.getId(),
+      ethers.utils.hexZeroPad('0x0', 32),
+      'mining',
+      account,
+    )
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nevermined-io/sdk",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Javascript SDK for connecting with Nevermined Data Platform ",
   "main": "./dist/node/sdk.js",
   "typings": "./dist/node/sdk.d.ts",

--- a/src/keeper/contracts/conditions/Condition.abstract.ts
+++ b/src/keeper/contracts/conditions/Condition.abstract.ts
@@ -85,8 +85,8 @@ export abstract class ConditionSmall extends ContractBase {
     return [valueHash, await this.call<string>('generateId', [zeroX(agreementId), valueHash])]
   }
 
-  public abortByTimeOut(agreementId: string, from?: Account, params?: TxParameters) {
-    return this.sendFrom('abortByTimeOut', [zeroX(agreementId)], from, params)
+  public abortByTimeOut(conditionId: string, from?: Account, params?: TxParameters) {
+    return this.sendFrom('abortByTimeOut', [zeroX(conditionId)], from, params)
   }
 
   public getConditionFulfilledEvent(agreementId: string) {

--- a/src/keeper/contracts/templates/AgreementTemplate.abstract.ts
+++ b/src/keeper/contracts/templates/AgreementTemplate.abstract.ts
@@ -267,6 +267,13 @@ export abstract class AgreementTemplate<Params> extends ContractBase {
     const amounts = assetPrice.getAmounts()
     const receivers = assetPrice.getReceivers()
 
+    const timeouts: number[] = []
+    const timelocks: number[] = []
+    service.attributes.serviceAgreementTemplate.conditions.map((condition) => {
+      timeouts.push(condition.timeout)
+      timelocks.push(condition.timelock)
+    })
+
     observer(OrderProgressStep.ApprovingPayment)
     await this.lockTokens(tokenAddress, amounts, from, txParams)
     observer(OrderProgressStep.ApprovedPayment)
@@ -282,8 +289,8 @@ export abstract class AgreementTemplate<Params> extends ContractBase {
       agreementIdSeed,
       ddo.shortId(),
       instances.map((a) => a.seed),
-      new Array(instances.length).fill(0),
-      timeOuts ? timeOuts : new Array(instances.length).fill(0),
+      timelocks ? timelocks : new Array(instances.length).fill(0),
+      timeouts ? timeouts : new Array(instances.length).fill(0),
       consumer.getId(),
       this.lockConditionIndex(),
       rewardAddress,

--- a/src/models/AssetAttributes.ts
+++ b/src/models/AssetAttributes.ts
@@ -51,6 +51,26 @@ export class AssetAttributes {
    */
   appId?: string
 
+  /**
+   * An asset can offer different services. Each service can have different conditions that need to be fulfilled
+   * to provide that service. These conditions can expire if they are not fulfilled in a certain period of time.
+   * This attribute allows to specify the timeouts for the access condition associated to the service.
+   * Setting up a timeout of 0 means that the condition will never expire.
+   * Setting a timeout greater than 0 means that the condition will expire after that number of blocks after the agreement is created.
+   * This would allow to create an agreement that is not fulfilled after a certain period of time, the user can claim back funds locked if the condition is any.
+   */
+  fulfillAccessTimeout?: number
+
+  /**
+   * An asset can offer different services. Each service can have different conditions that need to be fulfilled
+   * to provide that service. These conditions can expire if they are not fulfilled in a certain period of time.
+   * This attribute allows to specify a period of time the condition can not be fullfilled
+   * Setting up a timelock of 0 means that the condition can be fulfilled at any time.
+   * Setting a timelock greater than 0 means that the condition can not be fulfilled until that number of blocks after the agreement is created are mined.
+   * This would allow to create an agreement that can not fulfilled until certain period of time.
+   */
+  fulfillAccessTimelock?: number
+
   static defaultValues = {
     price: new AssetPrice(), // It means there is no payment required
     encryptionMethod: AssetAttributes.DEFAULT_ENCRYPTION_METHOD, // The default encryption method for the internal metadata attributes is PSK-RSA
@@ -58,6 +78,8 @@ export class AssetAttributes {
     predefinedAssetServices: [] as Service[], // By default there in additional services to add to the asset
     providers: [], // By default there are no addresses registered as providers for the asset
     appId: '', // No appId by default
+    fulfillAccessTimeout: 0, // By default the access condition will never expire
+    fulfillAccessTimelock: 0, // By default the access condition can be fulfilled at any time
   }
 
   static getInstance(assetAttributes: AssetAttributes): Required<AssetAttributes> {

--- a/src/nevermined/api/RegistryBaseApi.ts
+++ b/src/nevermined/api/RegistryBaseApi.ts
@@ -140,6 +140,7 @@ export abstract class RegistryBaseApi extends Instantiable {
           fulfillAccessTimelock,
         } = nftAttributes || {}
         const sat: ServiceAgreementTemplate = service.attributes.serviceAgreementTemplate
+
         sat.conditions = fillConditionsWithDDO(
           name,
           sat.conditions,

--- a/src/nevermined/api/RegistryBaseApi.ts
+++ b/src/nevermined/api/RegistryBaseApi.ts
@@ -131,9 +131,17 @@ export abstract class RegistryBaseApi extends Instantiable {
 
       for (const name of assetAttributes.serviceTypes) {
         const service = ddo.findServiceByType(name)
-        const { nftContractAddress, amount, nftTransfer, duration } = nftAttributes || {}
+        const {
+          nftContractAddress,
+          amount,
+          nftTransfer,
+          duration,
+          fulfillAccessTimeout,
+          fulfillAccessTimelock,
+        } = nftAttributes || {}
         const sat: ServiceAgreementTemplate = service.attributes.serviceAgreementTemplate
         sat.conditions = fillConditionsWithDDO(
+          name,
           sat.conditions,
           ddo,
           assetAttributes.price,
@@ -143,6 +151,8 @@ export abstract class RegistryBaseApi extends Instantiable {
           amount,
           nftTransfer,
           duration,
+          fulfillAccessTimeout,
+          fulfillAccessTimelock,
         )
       }
 

--- a/src/nevermined/api/nfts/NFTsBaseApi.ts
+++ b/src/nevermined/api/nfts/NFTsBaseApi.ts
@@ -1,4 +1,4 @@
-import { DDO } from '../../../ddo'
+import { DDO, ServiceType } from '../../../ddo'
 import {
   fillConditionsWithDDO,
   findServiceConditionByName,
@@ -247,6 +247,7 @@ export abstract class NFTsBaseApi extends RegistryBaseApi {
     token: Token,
     owner: string,
   ): Promise<string> {
+    const serviceType: ServiceType = 'nft-sales'
     const { nftSalesTemplate } = this.nevermined.keeper.templates
     const agreementIdSeed = zeroX(generateId())
     const nftSalesServiceAgreementTemplate = await nftSalesTemplate.getServiceAgreementTemplate()
@@ -254,6 +255,7 @@ export abstract class NFTsBaseApi extends RegistryBaseApi {
       await nftSalesTemplate.getServiceAgreementTemplateConditions()
 
     nftSalesServiceAgreementTemplate.conditions = fillConditionsWithDDO(
+      serviceType,
       nftSalesTemplateConditions,
       ddo,
       assetPrice,
@@ -265,7 +267,7 @@ export abstract class NFTsBaseApi extends RegistryBaseApi {
 
     const nftSalesServiceAgreement: ServiceSecondary = {
       agreementId: agreementIdSeed,
-      type: 'nft-sales',
+      type: serviceType,
       index: 6,
       serviceEndpoint: this.nevermined.services.node.getNftEndpoint(),
       templateId: nftSalesTemplate.getAddress(),

--- a/src/utils/DDOHelpers.ts
+++ b/src/utils/DDOHelpers.ts
@@ -10,7 +10,7 @@ import { AssetPrice } from '../models'
 import { BigNumber } from './BigNumber'
 
 // DDO Services including a sales process
-const SALES_SERVICES = ['nft-sales', 'access', 'compute', 'nft-sales']
+const SALES_SERVICES = ['access', 'compute', 'nft-sales']
 // Condition Names that are the final dependency for releasing the payment in a service agreement
 const DEPENDENCIES_RELEASE_CONDITION = ['access', 'serviceExecution', 'transferNFT']
 
@@ -89,35 +89,33 @@ export function fillConditionsWithDDO(
   fulfillAccessTimeout = 0,
   fulfillAccessTimelock = 0,
 ): ServiceAgreementTemplateCondition[] {
-  conditions.map((condition) => {
-    if (
-      DEPENDENCIES_RELEASE_CONDITION.includes(condition.name) &&
-      SALES_SERVICES.includes(serviceType)
-    ) {
-      if (fulfillAccessTimeout > 0) {
+  return conditions
+    .map((condition) => {
+      if (
+        DEPENDENCIES_RELEASE_CONDITION.includes(condition.name) &&
+        SALES_SERVICES.includes(serviceType)
+      ) {
         condition.timeout = fulfillAccessTimeout
-      }
-      if (fulfillAccessTimelock > 0) {
         condition.timelock = fulfillAccessTimelock
       }
-    }
-  })
-  return conditions.map((condition) => ({
-    ...condition,
-    parameters: condition.parameters.map((parameter) => ({
-      ...fillParameterWithDDO(
-        parameter,
-        ddo,
-        assetPrice,
-        erc20TokenContract,
-        nftTokenContract,
-        nftHolder,
-        nftAmount,
-        nftTransfer,
-        duration,
-      ),
-    })),
-  }))
+      return condition
+    })
+    .map((condition) => ({
+      ...condition,
+      parameters: condition.parameters.map((parameter) => ({
+        ...fillParameterWithDDO(
+          parameter,
+          ddo,
+          assetPrice,
+          erc20TokenContract,
+          nftTokenContract,
+          nftHolder,
+          nftAmount,
+          nftTransfer,
+          duration,
+        ),
+      })),
+    }))
 }
 
 export function findServiceConditionByName(

--- a/src/utils/DDOHelpers.ts
+++ b/src/utils/DDOHelpers.ts
@@ -9,6 +9,11 @@ import {
 import { AssetPrice } from '../models'
 import { BigNumber } from './BigNumber'
 
+// DDO Services including a sales process
+const SALES_SERVICES = ['nft-sales', 'access', 'compute', 'nft-sales']
+// Condition Names that are the final dependency for releasing the payment in a service agreement
+const DEPENDENCIES_RELEASE_CONDITION = ['access', 'serviceExecution', 'transferNFT']
+
 function fillParameterWithDDO(
   parameter: ServiceAgreementTemplateParameter,
   ddo: DDO,
@@ -71,6 +76,7 @@ function fillParameterWithDDO(
  * @returns Filled conditions.
  */
 export function fillConditionsWithDDO(
+  serviceType: ServiceType,
   conditions: ServiceAgreementTemplateCondition[],
   ddo: DDO,
   assetPrice: AssetPrice = new AssetPrice(),
@@ -80,7 +86,22 @@ export function fillConditionsWithDDO(
   nftAmount?: BigNumber,
   nftTransfer = false,
   duration = 0,
+  fulfillAccessTimeout = 0,
+  fulfillAccessTimelock = 0,
 ): ServiceAgreementTemplateCondition[] {
+  conditions.map((condition) => {
+    if (
+      DEPENDENCIES_RELEASE_CONDITION.includes(condition.name) &&
+      SALES_SERVICES.includes(serviceType)
+    ) {
+      if (fulfillAccessTimeout > 0) {
+        condition.timeout = fulfillAccessTimeout
+      }
+      if (fulfillAccessTimelock > 0) {
+        condition.timelock = fulfillAccessTimelock
+      }
+    }
+  })
   return conditions.map((condition) => ({
     ...condition,
     parameters: condition.parameters.map((parameter) => ({


### PR DESCRIPTION
## Description

This change allows content publishers to specify (optionally):
* A timelock parameter (number of blocks). If is higher than 0 that means the access conditions can not be fulfilled before X number of blocks since the agreement was created
* A timeout parameter (number of blocks). If is higher than 0 that means the access conditions can not be fulfilled after the timeout, and the access condition can be aborted and the user claim the payment back

A full flow can be showed in the `ClaimPaymentAbortedAgreement.test.ts` integration test.

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation
