### PR TITLE
Setting up a default timeout for fulfilling access conditions

### DIFF
--- a/integration/resources/ddo-nft.json
+++ b/integration/resources/ddo-nft.json
@@ -151,7 +151,7 @@
             {
               "name": "transferNFT",
               "timelock": 0,
-              "timeout": 0,
+              "timeout": 90,
               "contractName": "TransferNFTCondition",
               "functionName": "fulfill",
               "parameters": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nevermined-io/sdk",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "description": "Javascript SDK for connecting with Nevermined Data Platform ",
   "main": "./dist/node/sdk.js",
   "typings": "./dist/node/sdk.d.ts",

--- a/src/models/AssetAttributes.ts
+++ b/src/models/AssetAttributes.ts
@@ -78,7 +78,7 @@ export class AssetAttributes {
     predefinedAssetServices: [] as Service[], // By default there in additional services to add to the asset
     providers: [], // By default there are no addresses registered as providers for the asset
     appId: '', // No appId by default
-    fulfillAccessTimeout: 0, // By default the access condition will never expire
+    fulfillAccessTimeout: 90, // By default the access condition will never expire
     fulfillAccessTimelock: 0, // By default the access condition can be fulfilled at any time
   }
 


### PR DESCRIPTION
## Description

Before this PR the access condition (access, transferNFT) had a default timeout of 0 (no timeout).
That meant the user locked the payment and if for any reason was not able to fulfill the access condition (error of the network, the node, etc),
the funds were stuck.
Increasing this timeout to 90 blocks by default (around 3 minutes in 2 sec block time networks) would allow users to abort the 
transfer condition, and claim back the funds.

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()
