### PR TITLE
Feat/eip712 typed signatures

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nevermined-io/sdk",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Javascript SDK for connecting with Nevermined Data Platform ",
   "main": "./dist/node/sdk.js",
   "typings": "./dist/node/sdk.d.ts",


### PR DESCRIPTION
## Description

- Add the ability to create jwt tokens using the EIP-712 typed signatures standard
- `generateClientAssertion` now allows to pass a message to display in metamask

## Is this PR related with an open issue?

Related to Issue https://github.com/nevermined-io/one/issues/279

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()
