### PR TITLE
Making Curve & Aave contracts optional

### DIFF
--- a/aave_integration/nevermined/AaveCredit.test.ts
+++ b/aave_integration/nevermined/AaveCredit.test.ts
@@ -81,6 +81,7 @@ describe('AaveCredit', () => {
     // await TestContractHandler.prepareContracts()
 
     nevermined = await Nevermined.getInstance(config)
+    await nevermined.keeper.loadAaveInstances()
     ;({ agreementFee } = config.aaveConfig)
     ;({ aaveCreditTemplate } = nevermined.keeper.templates)
     ;({ conditionStoreManager, didRegistry, agreementStoreManager } = nevermined.keeper)

--- a/integration/nevermined/Artifacts.test.ts
+++ b/integration/nevermined/Artifacts.test.ts
@@ -8,10 +8,10 @@ describe('Artifacts', () => {
   const artifactsRepo = 'https://artifacts.nevermined.network/'
   const tests = [
     {
-      web3ProviderUri: 'https://matic-mumbai.chainstacklabs.com',
-      networkName: ['mumbai'],
-      networkId: [80001],
-      versions: ['v3.2.1'],
+      web3ProviderUri: 'https://goerli-rollup.arbitrum.io/rpc',
+      networkName: ['arbitrum-goerli'],
+      networkId: [421613],
+      versions: ['v3.2.2'],
       tag: 'public',
     },
   ]

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "mocha",
     "test:watch": "mocha -w --watch-extensions js,ts,json",
     "test:cover": "nyc --report-dir coverage/unit mocha --opts test/mocha.opts ./test/**/*.test.ts",
-    "integration": "mocha --opts integration/mocha.opts ./integration/**/*.test.ts",
+    "integration": "mocha --opts integration/mocha.opts ",
     "integration:subgraph": "mocha --opts integration/mocha.opts ./integration/**/*.test.subgraph.ts",
     "integration:production": "export NETWORK_NAME=production; yarn integration",
     "integration:staging": "export NETWORK_NAME=staging; yarn integration",

--- a/src/keeper/Keeper.ts
+++ b/src/keeper/Keeper.ts
@@ -72,7 +72,7 @@ export class Keeper extends Instantiable {
         // Main contracts
         dispenser: undefined, // Optional
         token: undefined, // Optional
-        curveRoyalties: undefined, // Optional
+        curveRoyalties: undefined, // Optional        
         nvmConfig: NeverminedConfig.getInstance(this.instanceConfig),
         didRegistry: DIDRegistry.getInstance(this.instanceConfig),
         // Managers
@@ -93,14 +93,16 @@ export class Keeper extends Instantiable {
         transferDidOwnershipCondition: TransferDIDOwnershipCondition.getInstance(
           this.instanceConfig,
         ),
-        aaveBorrowCondition: AaveBorrowCondition.getInstance(this.instanceConfig),
-        aaveCollateralDepositCondition: AaveCollateralDepositCondition.getInstance(
-          this.instanceConfig,
-        ),
-        aaveCollateralWithdrawCondition: AaveCollateralWithdrawCondition.getInstance(
-          this.instanceConfig,
-        ),
-        aaveRepayCondition: AaveRepayCondition.getInstance(this.instanceConfig),
+
+        // Aave instances are optional
+        aaveBorrowCondition: undefined,
+        aaveCollateralDepositCondition: undefined,
+        aaveCollateralWithdrawCondition: undefined,
+        aaveRepayCondition: undefined,
+        aaveCreditTemplate: undefined,
+
+
+
         nft721LockCondition: NFT721LockCondition.getInstance(this.instanceConfig),
         distributeNftCollateralCondition: DistributeNFTCollateralCondition.getInstance(
           this.instanceConfig,
@@ -115,7 +117,6 @@ export class Keeper extends Instantiable {
         didSalesTemplate: DIDSalesTemplate.getInstance(this.instanceConfig),
         nftSalesTemplate: NFTSalesTemplate.getInstance(this.instanceConfig),
         nft721SalesTemplate: NFT721SalesTemplate.getInstance(this.instanceConfig),
-        aaveCreditTemplate: AaveCreditTemplate.getInstance(this.instanceConfig), // optional
         standardRoyalties: StandardRoyalties.getInstance(this.instanceConfig), // optional
         rewardsDistributor: RewardsDistributor.getInstance(this.instanceConfig),
         nftUpgradeable: Nft1155Contract.getInstance(this.instanceConfig),
@@ -123,7 +124,7 @@ export class Keeper extends Instantiable {
 
       this.royalties = {
         standard: this.instances.standardRoyalties,
-        curve: this.instances.curveRoyalties,
+        curve: undefined,
       }
 
       this.rewardsDistributor = this.instances.rewardsDistributor
@@ -136,7 +137,6 @@ export class Keeper extends Instantiable {
         this.instances.didSalesTemplate,
         this.instances.nftSalesTemplate,
         this.instances.nft721SalesTemplate,
-        this.instances.aaveCreditTemplate,
       ]
 
       const templateObj: any = {}
@@ -167,12 +167,6 @@ export class Keeper extends Instantiable {
       this.logger.debug('Token not available on this network.')
     }
 
-    try {
-      this.instances.curveRoyalties = await CurveRoyalties.getInstance(this.instanceConfig)
-    } catch {
-      this.logger.debug('CurveRoyalties not available on this network.')
-    }
-
     // Main contracts
     this.dispenser = this.instances.dispenser
     this.token = this.instances.token
@@ -196,10 +190,10 @@ export class Keeper extends Instantiable {
       transferNftCondition: this.instances.transferNftCondition,
       transferNft721Condition: this.instances.transferNft721Condition,
       transferDidOwnershipCondition: this.instances.transferDidOwnershipCondition,
-      aaveBorrowCondition: this.instances.aaveBorrowCondition,
-      aaveCollateralDepositCondition: this.instances.aaveCollateralDepositCondition,
-      aaveCollateralWithdrawCondition: this.instances.aaveCollateralWithdrawCondition,
-      aaveRepayCondition: this.instances.aaveRepayCondition,
+      aaveBorrowCondition: undefined,
+      aaveCollateralDepositCondition: undefined,
+      aaveCollateralWithdrawCondition: undefined,
+      aaveRepayCondition: undefined,
       nft721LockCondition: this.instances.nft721LockCondition,
       distributeNftCollateralCondition: this.instances.distributeNftCollateralCondition,
     }
@@ -213,7 +207,7 @@ export class Keeper extends Instantiable {
       nft721AccessTemplate: this.instances.nft721AccessTemplate,
       nftSalesTemplate: this.instances.nftSalesTemplate,
       nft721SalesTemplate: this.instances.nft721SalesTemplate,
-      aaveCreditTemplate: this.instances.aaveCreditTemplate,
+      aaveCreditTemplate: undefined
     }
     this.templateList = [
       this.instances.accessTemplate,
@@ -408,6 +402,42 @@ export class Keeper extends Instantiable {
 
   public getAllInstances() {
     return this.instances
+  }
+
+  public async loadAaveInstances() {
+    if (this.instances.aaveCreditTemplate) return this
+
+    this.logger.debug('Loading Aave contracts')
+    this.instances.aaveBorrowCondition = await AaveBorrowCondition.getInstance(this.instanceConfig)
+    this.instances.aaveCollateralDepositCondition = await AaveCollateralDepositCondition.getInstance(
+      this.instanceConfig,
+    )
+    this.instances.aaveCollateralWithdrawCondition = await AaveCollateralWithdrawCondition.getInstance(
+      this.instanceConfig,
+    )
+    this.instances.aaveRepayCondition = await AaveRepayCondition.getInstance(this.instanceConfig)
+
+    this.conditions.aaveBorrowCondition = this.instances.aaveBorrowCondition
+    this.conditions.aaveCollateralDepositCondition = this.instances.aaveCollateralDepositCondition
+    this.conditions.aaveCollateralWithdrawCondition = this.instances.aaveCollateralWithdrawCondition
+    this.conditions.aaveRepayCondition = this.instances.aaveRepayCondition
+    this.conditionsList = Object.values(this.conditions)
+
+    this.instances.aaveCreditTemplate = await AaveCreditTemplate.getInstance(this.instanceConfig)
+    this.templates.aaveCreditTemplate = this.instances.aaveCreditTemplate
+    this.agreementStoreManager.addTemplate('AaveCreditTemplate', this.instances.aaveCreditTemplate)
+    return this
+  }
+
+  public async loadCurveRoyaltiesInstance() {
+    if (this.royalties.curve) return this.royalties.curve
+
+    try {
+      this.royalties.curve = await CurveRoyalties.getInstance(this.instanceConfig)
+    } catch {
+      this.logger.debug('CurveRoyalties not available on this network.')
+    }
+    return this.royalties.curve
   }
 }
 

--- a/test/bookmarks/Bookmarks.test.ts
+++ b/test/bookmarks/Bookmarks.test.ts
@@ -5,6 +5,7 @@ import { Nevermined } from '../../src'
 import { MarketplaceResults } from '../../src/common/interfaces'
 import config from '../config'
 import { Bookmark, Bookmarks, NewBookmark } from '../../src/services'
+import TestContractHandler from '../keeper/TestContractHandler'
 
 use(spies)
 
@@ -20,8 +21,12 @@ describe('Bookmarks', () => {
   let bookmark: Bookmark
   let bookmarksResults: MarketplaceResults<Bookmark>
 
-  beforeEach(async () => {
+  before(async () => {
+    await TestContractHandler.prepareContracts()
     nevermined = await Nevermined.getInstance(config)
+  })
+
+  beforeEach(async () => {    
     bookmarks = nevermined.services.bookmarks // eslint-disable-line prefer-destructuring
 
     newBookmark = {

--- a/test/config.ts
+++ b/test/config.ts
@@ -3,7 +3,7 @@ import { LoggerInstance } from '../src/utils'
 
 LoggerInstance.setLevel(LogLevel.Error)
 
-export default {
+export default {  
   marketplaceUri: 'http://localhost:3100',
   neverminedNodeUri: 'http://localhost:8030',
   neverminedNodeAddress: '0x068ed00cf0441e4829d9784fcbe7b9e26d4bd8d0',

--- a/test/keeper/Keeper.test.ts
+++ b/test/keeper/Keeper.test.ts
@@ -27,6 +27,14 @@ describe('Keeper', () => {
     it('should have token', () => {
       assert(keeper.token !== null)
     })
+
+    it('should not have curve royalties', () => {
+      assert(keeper.royalties.curve === undefined, 'should not have curve royalties')
+    })
+
+    it('should not have Aave contracts', () => {
+      assert(keeper.templates!.aaveCreditTemplate! === undefined, 'should not have aave templates')
+    })
   })
 
   describe('#getNetworkName()', () => {

--- a/test/keeper/conditions/AaveBorrowCondition.test.ts
+++ b/test/keeper/conditions/AaveBorrowCondition.test.ts
@@ -27,7 +27,12 @@ describe('AaveBorrowCondition', () => {
     nevermined = await Nevermined.getInstance(config)
     ;[user] = await nevermined.accounts.list()
     ;({ didRegistry } = nevermined.keeper)
-    condition = (await Nevermined.getInstance(config)).keeper.conditions.aaveBorrowCondition
+    condition = 
+      (await (
+        await Nevermined.getInstance(config))
+        .keeper.loadAaveInstances())
+        .conditions.aaveBorrowCondition    
+    
   })
 
   beforeEach(async () => {
@@ -49,16 +54,6 @@ describe('AaveBorrowCondition', () => {
 
       const id = await condition.generateId(agreementId, hash)
       assert.match(id, /^0x[a-f0-9]{64}$/i)
-
-      // const txReceipt: TransactionReceipt = await condition.fulfill(
-      //     agreementId,
-      //     did,
-      //     vaultAddress,
-      //     assetToBorrow,
-      //     amount,
-      //     interestRateMode,
-      //     user
-      // )
     })
   })
 })

--- a/test/keeper/conditions/AaveCollateralDepositCondition.test.ts
+++ b/test/keeper/conditions/AaveCollateralDepositCondition.test.ts
@@ -29,8 +29,11 @@ describe('AaveCollateralDepositCondition', () => {
     nevermined = await Nevermined.getInstance(config)
     ;[user] = await nevermined.accounts.list()
     ;({ didRegistry } = nevermined.keeper)
-    condition = (await Nevermined.getInstance(config)).keeper.conditions
-      .aaveCollateralDepositCondition
+    condition = 
+    (await (
+      await Nevermined.getInstance(config))
+      .keeper.loadAaveInstances())
+      .conditions.aaveCollateralDepositCondition
   })
 
   beforeEach(async () => {

--- a/test/keeper/conditions/AaveCollateralWithdrawCondition.test.ts
+++ b/test/keeper/conditions/AaveCollateralWithdrawCondition.test.ts
@@ -24,8 +24,11 @@ describe('AaveCollateralWithdrawCondition', () => {
     nevermined = await Nevermined.getInstance(config)
     ;[user] = await nevermined.accounts.list()
     ;({ didRegistry } = nevermined.keeper)
-    condition = (await Nevermined.getInstance(config)).keeper.conditions
-      .aaveCollateralWithdrawCondition
+    condition = 
+    (await (
+      await Nevermined.getInstance(config))
+      .keeper.loadAaveInstances())
+      .conditions.aaveCollateralWithdrawCondition
   })
 
   beforeEach(async () => {

--- a/test/keeper/conditions/AaveRepayCondition.test.ts
+++ b/test/keeper/conditions/AaveRepayCondition.test.ts
@@ -27,7 +27,11 @@ describe('AaveRepayCondition', () => {
     nevermined = await Nevermined.getInstance(config)
     ;[user] = await nevermined.accounts.list()
     ;({ didRegistry } = nevermined.keeper)
-    condition = (await Nevermined.getInstance(config)).keeper.conditions.aaveRepayCondition
+    condition = 
+    (await (
+      await Nevermined.getInstance(config))
+      .keeper.loadAaveInstances())
+      .conditions.aaveRepayCondition
   })
 
   beforeEach(async () => {


### PR DESCRIPTION
## Description

With this feature the Curve and Aave* contracts need to be loaded via keeper methods

- fix: making aave and curve royalties contracts optional
- test: avoiding polygon web3 provider because low availability


## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()
