### PR TITLE
fix: form-data lib was missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nevermined-io/sdk",
-  "version": "2.0.0-rc10",
+  "version": "2.0.0-rc11",
   "description": "Javascript SDK for connecting with Nevermined Data Platform ",
   "main": "./dist/node/sdk.js",
   "typings": "./dist/node/sdk.d.ts",
@@ -59,6 +59,7 @@
     "ethers": "^6.7.1",
     "graphql": "^16.7.1",
     "https-browserify": "^1.0.0",
+    "form-data": "^4.0.0",
     "jose": "^4.5.1",
     "js-file-download": "^0.4.12",
     "lodash": "^4.17.21",


### PR DESCRIPTION
## Description

form-data lib was lost so apps integrating the SDK were having to include the dependency to avoid compilation issues.

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()
