### PR TITLE
fix: issue where ethers signTypedData was not being called correctly

### DIFF
--- a/integration/nevermined/MarketplaceAPIAuth.test.ts
+++ b/integration/nevermined/MarketplaceAPIAuth.test.ts
@@ -33,6 +33,15 @@ describe('Marketplace api auth', () => {
     }
   })
 
+  it('should login using a message', async () => {
+    const clientAssertion = await nevermined.utils.jwt.generateClientAssertion(
+      account1,
+      'Nevermined',
+    )
+    const accessToken = await nevermined.services.marketplace.login(clientAssertion)
+    assert.isDefined(accessToken)
+  })
+
   it('should add new address to the account', async () => {
     const clientAssertion = await nevermined.utils.jwt.generateClientAssertion(account2)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nevermined-io/sdk",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Javascript SDK for connecting with Nevermined Data Platform ",
   "main": "./dist/node/sdk.js",
   "typings": "./dist/node/sdk.d.ts",
@@ -51,9 +51,10 @@
   },
   "homepage": "https://github.com/nevermined-io/sdk-js#readme",
   "dependencies": {
-    "@alchemy/aa-core": "0.1.0",
+    "@alchemy/aa-core": "0.1.1",
     "@apollo/client": "^3.7.16",
-    "@zerodev/sdk": "4.0.30",
+    "@turnkey/ethers": "0.17.4",
+    "@zerodev/sdk": "4.0.31",
     "assert": "^2.0.0",
     "cross-fetch": "^4.0.0",
     "crypto-browserify": "^3.12.0",

--- a/src/nevermined/utils/JwtUtils.ts
+++ b/src/nevermined/utils/JwtUtils.ts
@@ -122,7 +122,7 @@ export class EthSignJWT extends SignJWT {
         primaryType: '',
       })
     }
-    return EthSignJWT.signTypedMessage(domain, types, value, signer)
+    return signer.signTypedData(domain, types as any, value)
   }
 
   private base64url(input: Uint8Array | string): string {


### PR DESCRIPTION


## Description

- fix issue where the ethers signer was not being called correctly for typed message signatures
- bump version to 2.0.2
- added `@turnkey/ethers` has a dependency to prevent compilation warnings coming from zerodev

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()
