### PR TITLE
Allowing credits asset publisher to download files

### DIFF
--- a/integration/external/Services_NFT1155.e2e.test.ts
+++ b/integration/external/Services_NFT1155.e2e.test.ts
@@ -206,7 +206,7 @@ describe('Gate-keeping of Web Services using NFT ERC-1155 End-to-End', () => {
       const isOperator = await subscriptionNFT.getContract.isOperator(transferNftCondition.address)
       assert.isTrue(isOperator)
 
-      subscriptionMetadata = getMetadata(undefined, 'Service Subscription NFT1155')
+      subscriptionMetadata = getMetadata(Math.random().toString(), 'Service Subscription NFT1155')
       subscriptionMetadata.main.type = 'subscription'
       const nftAttributes = NFTAttributes.getCreditsSubscriptionInstance({
         metadata: subscriptionMetadata,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nevermined-io/sdk",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Javascript SDK for connecting with Nevermined Data Platform ",
   "main": "./dist/node/sdk.js",
   "typings": "./dist/node/sdk.d.ts",

--- a/src/ddo/DDO.ts
+++ b/src/ddo/DDO.ts
@@ -24,6 +24,7 @@ import {
   DDOParamNotFoundError,
   DDOServiceAlreadyExists,
 } from '../errors/DDOError'
+import { jsonReplacer } from '../common'
 
 // DDO Services including a sales process
 export const SALES_SERVICES = ['access', 'compute', 'nft-sales']
@@ -41,7 +42,7 @@ export class DDO {
    * @returns DDO serialized.
    */
   public static serialize(ddo: DDO): string {
-    return JSON.stringify(ddo, null, 2)
+    return JSON.stringify(ddo, jsonReplacer, 2)
   }
 
   /**
@@ -244,7 +245,7 @@ export class DDO {
     const checksum = {}
     this.service.forEach((svc) => {
       checksum[svc.index] = this.checksum(
-        JSON.stringify(this.findServiceByType(svc.type).attributes.main),
+        JSON.stringify(this.findServiceByType(svc.type).attributes.main, jsonReplacer),
       )
     })
     return {

--- a/src/keeper/contracts/templates/NFTAccessTemplate.ts
+++ b/src/keeper/contracts/templates/NFTAccessTemplate.ts
@@ -163,6 +163,15 @@ export class NFTAccessTemplate extends BaseTemplate<NFTAccessTemplateParams, Ser
       return false
     }
 
+    const subscriptionOwner = await this.nevermined.assets.owner(ddo.id)
+    const consumerIsOwner =
+      params.consumer_address.toLowerCase() === subscriptionOwner.toLowerCase()
+
+    if (consumerIsOwner) {
+      // User calling is the asset owner so skipping track()
+      return false
+    }
+
     const nftAccessService = (
       params.service_index && params.service_index > 0
         ? ddo.findServiceByIndex(params.service_index)


### PR DESCRIPTION
## Description

When publishers of a credit subscription try to download a file the sdk is not checking if the user is an owner an try to burn credits. This fix does a validation and skip if the user is an owner.

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()
