### PR TITLE
Fixing issue with testnet validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nevermined-io/sdk",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Javascript SDK for connecting with Nevermined Data Platform ",
   "main": "./dist/node/sdk.js",
   "typings": "./dist/node/sdk.d.ts",

--- a/src/keeper/utils.ts
+++ b/src/keeper/utils.ts
@@ -62,7 +62,7 @@ export async function getNetworkName(networkId: number): Promise<string> {
       throw new KeeperError(`Network with id ${networkId} not supported.`)
   }
 }
-export async function isTestnet(networkId: number): Promise<boolean> {
+export function isTestnet(networkId: number): boolean {
   switch (networkId) {
     case 1:
       return false


### PR DESCRIPTION
## Description

- fix: isTestnet doesnt need to be async

The current version fails when connect to production networks because the isTestnet function doesnt need to be async


## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()
