### PR TITLE
Generation of JWTs representing the NVM Key hash

### DIFF
--- a/integration/nevermined/NVMApiKey.test.ts
+++ b/integration/nevermined/NVMApiKey.test.ts
@@ -8,6 +8,7 @@ import { NvmAccount } from '../../src/models/NvmAccount'
 import { JwtUtils, NvmApiKey } from '../../src'
 import { encryptMessage, decryptMessage } from '../../src/common/helpers'
 import { sleep } from '../utils/utils'
+import { decodeJwt } from 'jose'
 
 chai.use(chaiAsPromised)
 
@@ -138,6 +139,20 @@ describe('Nevermined API Key', () => {
       const hash = NvmApiKey.hash(encryptedNvmApiKey)
       console.log('Hash:', hash)
       assert.isDefined(hash)
+    })
+
+    it('A hash of the api key in JWT can be generated', async () => {
+      assert.isDefined(nvmApiKey)
+      const hashJwt = await nvmApiKey.hashJWT(nvm.utils.signature, user)
+      console.log('Hash (JWT):', hashJwt)
+      assert.isDefined(hashJwt)
+
+      const hashDecoded = decodeJwt(hashJwt)
+      assert.isDefined(hashDecoded)
+      console.log('Hash (JWT) Decoded:', hashDecoded)
+
+      const signerAddress = await NvmApiKey.getSignerAddress(hashJwt)
+      assert.strictEqual(signerAddress, user.getId())
     })
 
     it('The api token is not valid if already expired', async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nevermined-io/sdk",
-  "version": "3.0.20",
+  "version": "3.0.21",
   "description": "Javascript SDK for connecting with Nevermined Data Platform ",
   "main": "./dist/node/sdk.js",
   "typings": "./dist/node/sdk.d.ts",

--- a/src/models/NvmApiKey.ts
+++ b/src/models/NvmApiKey.ts
@@ -222,7 +222,6 @@ export class NvmApiKey implements JWTPayload {
       iss: address,
       sub: this.hash(),
       exp: this.exp,
-      eths: 'personal',
     })
       .setProtectedHeader({ alg: 'ES256K' })
       .setIssuedAt()


### PR DESCRIPTION
- **feat: utility methods to generate a JWT from the hash of the key**
- **feat: using expiration but not eths as jwt attributes**

## Description

Add a description of your changes here.

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()
